### PR TITLE
Use the quiet option correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,8 +235,8 @@ impl<CL: Command> Runner<CL> {
         self
     }
 
-    pub fn quiet(&mut self, verbose_opt: bool) -> &mut Self {
-        self.quiet = verbose_opt;
+    pub fn quiet(&mut self, quiet_opt: bool) -> &mut Self {
+        self.quiet = quiet_opt;
         self
     }
 
@@ -248,7 +248,7 @@ impl<CL: Command> Runner<CL> {
     fn to_options(&self) -> Options {
         Options {
             restart: self.restart.clone(),
-            verbose: self.quiet,
+            verbose: !self.quiet,
             file_handle_flags: self.file_handle_flags,
         }
     }


### PR DESCRIPTION
The current implementation sets the `verbose` option to the same value as `quiet`, while it should be the negated value.

I also defined #5 for a related cleanup in this area.