### PR TITLE
Use a borrow-based API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,12 @@ impl Command for ChannelCommand {
     }
 }
 
+impl AsRef<ChannelCommand> for ChannelCommand {
+    fn as_ref(&self) -> &ChannelCommand {
+        self
+    }
+}
+
 #[derive(Clone)]
 pub struct InnerCommand {
     name: String,
@@ -56,7 +62,7 @@ pub struct InnerCommand {
     env: HashMap<String, String>,
 }
 
-pub trait Command
+pub trait Command: Clone
 where
     Self: Sized,
 {
@@ -215,7 +221,7 @@ impl<C: Command> Default for Runner<C> {
     }
 }
 
-impl<CL: Command> Runner<CL> {
+impl<C: Command> Runner<C> {
     pub fn new() -> Self {
         Runner {
             commands: Vec::new(),
@@ -225,8 +231,8 @@ impl<CL: Command> Runner<CL> {
         }
     }
 
-    pub fn command(&mut self, cmd: CL) -> &mut Self {
-        self.commands.push(cmd);
+    pub fn command<T: AsRef<C>>(&mut self, cmd: T) -> &mut Self {
+        self.commands.push(cmd.as_ref().clone());
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ mod line_parse;
 mod standard_out_api;
 mod writer_api;
 
-use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::io;
 use std::io::BufRead;
@@ -57,7 +56,7 @@ pub struct InnerCommand {
     env: HashMap<String, String>,
 }
 
-pub trait Command: Clone
+pub trait Command
 where
     Self: Sized,
 {
@@ -199,7 +198,7 @@ pub enum RestartOptions {
 #[derive(Clone)]
 struct Options {
     restart: RestartOptions,
-    verbose: bool,
+    quiet: bool,
     file_handle_flags: bool,
 }
 
@@ -226,8 +225,8 @@ impl<CL: Command> Runner<CL> {
         }
     }
 
-    pub fn command<T: Borrow<CL>>(&mut self, cmd: T) -> &mut Runner<CL> {
-        self.commands.push(cmd.borrow().clone());
+    pub fn command(&mut self, cmd: CL) -> &mut Self {
+        self.commands.push(cmd);
         self
     }
 
@@ -249,14 +248,14 @@ impl<CL: Command> Runner<CL> {
     fn to_options(&self) -> Options {
         Options {
             restart: self.restart.clone(),
-            verbose: !self.quiet,
+            quiet: self.quiet,
             file_handle_flags: self.file_handle_flags,
         }
     }
 }
 
 impl Runner<ChannelCommand> {
-    pub fn execute(&self) -> CommandHandle {
+    pub fn execute(&mut self) -> CommandHandle {
         run_commands(self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ where
         }))
     }
 
-    fn cur_dir<D>(&mut self, dir: D) -> &Self
+    fn cur_dir<D>(&mut self, dir: D) -> &mut Self
     where
         D: Into<PathBuf>,
     {
@@ -116,7 +116,7 @@ where
         self
     }
 
-    fn env<K, V>(&mut self, key: K, val: V) -> &Self
+    fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
     where
         K: Into<String>,
         V: Into<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ where
         }))
     }
 
-    fn cur_dir<D>(mut self, dir: D) -> Self
+    fn cur_dir<D>(&mut self, dir: D) -> &Self
     where
         D: Into<PathBuf>,
     {
@@ -116,7 +116,7 @@ where
         self
     }
 
-    fn env<K, V>(mut self, key: K, val: V) -> Self
+    fn env<K, V>(&mut self, key: K, val: V) -> &Self
     where
         K: Into<String>,
         V: Into<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod line_parse;
 mod standard_out_api;
 mod writer_api;
 
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::io;
 use std::io::BufRead;
@@ -56,7 +57,7 @@ pub struct InnerCommand {
     env: HashMap<String, String>,
 }
 
-pub trait Command
+pub trait Command: Clone
 where
     Self: Sized,
 {
@@ -225,8 +226,8 @@ impl<CL: Command> Runner<CL> {
         }
     }
 
-    pub fn command(&mut self, cmd: CL) -> &mut Self {
-        self.commands.push(cmd);
+    pub fn command<T: Borrow<CL>>(&mut self, cmd: T) -> &mut Runner<CL> {
+        self.commands.push(cmd.borrow().clone());
         self
     }
 
@@ -255,7 +256,7 @@ impl<CL: Command> Runner<CL> {
 }
 
 impl Runner<ChannelCommand> {
-    pub fn execute(&mut self) -> CommandHandle {
+    pub fn execute(&self) -> CommandHandle {
         run_commands(self)
     }
 }

--- a/src/standard_out_api.rs
+++ b/src/standard_out_api.rs
@@ -18,7 +18,7 @@ pub struct ConsoleCommand {
 }
 
 impl ConsoleCommand {
-    pub fn color(mut self, color: Color) -> Self {
+    pub fn color(&mut self, color: Color) -> &mut Self {
         self.color = color;
         self
     }

--- a/src/standard_out_api.rs
+++ b/src/standard_out_api.rs
@@ -41,6 +41,12 @@ impl Command for ConsoleCommand {
     }
 }
 
+impl AsRef<ConsoleCommand> for ConsoleCommand {
+    fn as_ref(&self) -> &ConsoleCommand {
+        self
+    }
+}
+
 pub fn run_commands_stdout(runner: &Runner<ConsoleCommand>) -> ControlledCommandHandle {
     let mut name_color_hash = HashMap::new();
     let mut inner_commands = Vec::new();

--- a/src/writer_api.rs
+++ b/src/writer_api.rs
@@ -26,6 +26,12 @@ impl Command for WriterCommand {
     }
 }
 
+impl AsRef<WriterCommand> for WriterCommand {
+    fn as_ref(&self) -> &WriterCommand {
+        self
+    }
+}
+
 pub fn run_commands_writer<W>(runner: &Runner<WriterCommand>, writer: W) -> ControlledCommandHandle
 where
     W: Write + Send + 'static,


### PR DESCRIPTION
Change the builder functions to accept and return mutable references rather than consuming the builder