### PR TITLE
Run only typechecks on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,6 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.6
         with:
               toolchain: stable
-      - run: cargo build
+      - run: cargo check
       - run: cargo clippy --all-targets --all-features -- -D warnings
     

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,10 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: stable
-      - run: cargo build
+      - run: cargo check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - name: cargo login
         env:
           cargo_token: ${{ secrets.CARGO_TOKEN }}
         run: cargo login $cargo_token
       - run: cargo publish
-    


### PR DESCRIPTION
Building involves unnecessary slow code generation and to my knowledge doesn't result in additional error messages.