### PR TITLE
Badge for CI status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+name: build
 on: [push]
 jobs:
   build-code:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
-name: build and lint code
 on: [push]
 jobs:
   build-code:
@@ -10,4 +9,3 @@ jobs:
               toolchain: stable
       - run: cargo build
       - run: cargo clippy --all-targets --all-features -- -D warnings
-    

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Currant
 
-![build status](https://github.com/allonsy/currant/actions/workflows/build/badge.svg)
+![build status](https://github.com/allonsy/currant/actions/workflows/build.yml/badge.svg)
 
 A simple library to spawn concurrent shell processes in rust

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # Currant
+
+![build status](https://github.com/allonsy/currant/actions/workflows/build/badge.svg)
+
 A simple library to spawn concurrent shell processes in rust


### PR DESCRIPTION
The changes in `build.yml` are to make the badge a bit more concise. Right now it looks like this:

![image](https://user-images.githubusercontent.com/268934/146244039-9c9ab864-14df-4cd3-949c-a61a9b0ed18f.png)
