### PR TITLE
Add support for commands not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,14 @@ dependencies = [
  "atty",
  "rand",
  "shell-words",
+ "which",
 ]
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "getrandom"
@@ -47,6 +54,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -111,6 +124,17 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,6 @@ exclude = [
 atty = "0.2.14"
 rand = "0.8.4"
 shell-words = "1.0.0"
+which = "4.2.2"
 
 [features]

--- a/examples/main_stdout.rs
+++ b/examples/main_stdout.rs
@@ -5,7 +5,7 @@ use currant::Runner;
 fn main() {
     let handle = Runner::new()
         .command(
-            ConsoleCommand::from_string("test1", "lx -la .")
+            ConsoleCommand::from_string("test1", "ls -la .")
                 .unwrap()
                 .color(Color::BLUE),
         )

--- a/examples/main_stdout.rs
+++ b/examples/main_stdout.rs
@@ -5,7 +5,7 @@ use currant::Runner;
 fn main() {
     let handle = Runner::new()
         .command(
-            ConsoleCommand::from_string("test1", "ls -la .")
+            ConsoleCommand::from_string("test1", "lx -la .")
                 .unwrap()
                 .color(Color::BLUE),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,16 @@
 mod color;
 mod kill_barrier;
 mod line_parse;
+mod run;
 mod standard_out_api;
 mod writer_api;
 
 use std::collections::HashMap;
 use std::io;
-use std::io::BufRead;
-use std::io::BufReader;
 use std::io::Write;
 use std::path::PathBuf;
-use std::process;
 use std::process::ExitStatus;
 use std::sync::mpsc;
-use std::sync::Arc;
-use std::sync::Mutex;
 use std::thread;
 
 pub use color::Color;
@@ -286,178 +282,5 @@ fn run_commands<C: Command>(runner: &Runner<C>) -> CommandHandle {
         .iter()
         .map(|c| c.get_command().clone())
         .collect::<Vec<InnerCommand>>();
-    run_commands_internal(actual_cmds, runner.to_options())
-}
-
-fn run_commands_internal(commands: Vec<InnerCommand>, options: Options) -> CommandHandle {
-    let (send, recv) = mpsc::channel();
-    let kill_trigger = kill_barrier::KillBarrier::new();
-    let kill_trigger_clone = kill_trigger.clone();
-
-    let command_names: Vec<String> = commands.iter().map(|cmd| cmd.name.clone()).collect();
-
-    let handle = thread::spawn(move || {
-        let mut handles = Vec::new();
-        let mut statuses = Vec::new();
-        for cmd in commands {
-            handles.push(run_command(
-                cmd,
-                send.clone(),
-                options.clone(),
-                kill_trigger_clone.clone(),
-            ));
-        }
-
-        for (idx, handle) in handles.into_iter().enumerate() {
-            statuses.push(handle.join().unwrap_or((command_names[idx].clone(), None)));
-        }
-
-        statuses
-    });
-
-    CommandHandle {
-        handle,
-        channel: recv,
-        kill_trigger,
-    }
-}
-
-fn run_command(
-    command: InnerCommand,
-    send_chan: mpsc::Sender<OutputMessage>,
-    options: Options,
-    kill_trigger: kill_barrier::KillBarrier,
-) -> thread::JoinHandle<ExitResult> {
-    thread::spawn(move || loop {
-        let mut command_process = process::Command::new(&command.command);
-        command_process.args(&command.args);
-        if command.cur_dir.is_some() {
-            command_process.current_dir(command.cur_dir.clone().unwrap());
-        }
-        command_process.envs(command.env.clone());
-        command_process.stdout(process::Stdio::piped());
-        let command_name = command.name.clone();
-
-        let _ = send_chan.send(OutputMessage {
-            name: command_name.clone(),
-            message: OutputMessagePayload::Start,
-        });
-
-        let mut cmd_handle = command_process
-            .spawn()
-            .unwrap_or_else(|_| panic!("Unable to spawn process: {}", command.command.clone()));
-        let std_out = cmd_handle.stdout.take();
-        let std_err = cmd_handle.stderr.take();
-        let mut std_out_handle = None;
-        let mut std_err_handle = None;
-
-        let shared_handle = Arc::new(Mutex::new(cmd_handle));
-
-        let child_clone = shared_handle.clone();
-        let kill_trigger_clone = kill_trigger.clone();
-        thread::spawn(move || kill_thread(&kill_trigger_clone, child_clone));
-
-        if let Some(output) = std_out {
-            let mut buffered_stdout = BufReader::new(output);
-            let new_name = command_name.clone();
-            let new_chan = send_chan.clone();
-            std_out_handle = Some(thread::spawn(move || {
-                read_stream(&new_name, new_chan, &mut buffered_stdout, true);
-            }));
-        }
-
-        if let Some(output) = std_err {
-            let mut buffered_stdout = BufReader::new(output);
-            let new_name = command_name.clone();
-            let new_chan = send_chan.clone();
-            std_err_handle = Some(thread::spawn(move || {
-                read_stream(&new_name, new_chan, &mut buffered_stdout, false);
-            }));
-        }
-
-        if let Some(handle) = std_out_handle {
-            let _ = handle.join();
-        }
-
-        if let Some(handle) = std_err_handle {
-            let _ = handle.join();
-        }
-
-        let exit_status = shared_handle.lock().unwrap().wait();
-        match exit_status {
-            Ok(status) => {
-                let _ = send_chan.send(OutputMessage {
-                    name: command_name.clone(),
-                    message: OutputMessagePayload::Done(status.code()),
-                });
-
-                match options.restart {
-                    RestartOptions::Continue => {
-                        return (command_name, Some(status));
-                    }
-                    RestartOptions::Restart => {
-                        if status.success() {
-                            return (command_name, Some(status));
-                        }
-                    }
-                    RestartOptions::Kill => {
-                        if !status.success() {
-                            let _ = kill_trigger.initiate_kill();
-                        }
-                        return (command_name, Some(status));
-                    }
-                };
-            }
-            Err(e) => {
-                let _ = send_chan.send(OutputMessage {
-                    name: command_name.clone(),
-                    message: OutputMessagePayload::Error(e),
-                });
-                return (command_name, None);
-            }
-        }
-    })
-}
-
-fn kill_thread(kill_trigger: &kill_barrier::KillBarrier, child: Arc<Mutex<process::Child>>) {
-    let _ = kill_trigger.wait();
-
-    let lock_res = child.lock();
-    if let Ok(mut locked_child) = lock_res {
-        let _ = locked_child.kill();
-    }
-}
-
-fn read_stream<R>(
-    cmd_name: &str,
-    send_chan: mpsc::Sender<OutputMessage>,
-    reader: &mut R,
-    is_stdout: bool,
-) where
-    R: BufRead,
-{
-    loop {
-        let line = line_parse::get_line(reader);
-        match line {
-            Ok(Some(line_vec)) => {
-                let _ = send_chan.send(OutputMessage {
-                    name: cmd_name.to_string(),
-                    message: if is_stdout {
-                        OutputMessagePayload::Stdout(line_vec.0, line_vec.1)
-                    } else {
-                        OutputMessagePayload::Stderr(line_vec.0, line_vec.1)
-                    },
-                });
-            }
-            Ok(None) => {
-                return;
-            }
-            Err(e) => {
-                let _ = send_chan.send(OutputMessage {
-                    name: cmd_name.to_string(),
-                    message: OutputMessagePayload::Error(e),
-                });
-            }
-        }
-    }
+    run::run_commands_internal(actual_cmds, runner.to_options())
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,0 +1,192 @@
+use super::kill_barrier;
+use super::line_parse;
+use super::CommandHandle;
+use super::ExitResult;
+use super::InnerCommand;
+use super::Options;
+use super::OutputMessage;
+use super::OutputMessagePayload;
+use super::RestartOptions;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::process;
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::thread;
+
+pub(super) fn run_commands_internal(
+    commands: Vec<InnerCommand>,
+    options: Options,
+) -> CommandHandle {
+    let (send, recv) = mpsc::channel();
+    let kill_trigger = kill_barrier::KillBarrier::new();
+    let kill_trigger_clone = kill_trigger.clone();
+
+    let command_names: Vec<String> = commands.iter().map(|cmd| cmd.name.clone()).collect();
+
+    let handle = thread::spawn(move || {
+        let mut handles = Vec::new();
+        let mut statuses = Vec::new();
+        for cmd in commands {
+            handles.push(run_command(
+                cmd,
+                send.clone(),
+                options.clone(),
+                kill_trigger_clone.clone(),
+            ));
+        }
+
+        for (idx, handle) in handles.into_iter().enumerate() {
+            statuses.push(handle.join().unwrap_or((command_names[idx].clone(), None)));
+        }
+
+        statuses
+    });
+
+    CommandHandle {
+        handle,
+        channel: recv,
+        kill_trigger,
+    }
+}
+
+fn run_command(
+    command: InnerCommand,
+    send_chan: mpsc::Sender<OutputMessage>,
+    options: Options,
+    kill_trigger: kill_barrier::KillBarrier,
+) -> thread::JoinHandle<ExitResult> {
+    thread::spawn(move || loop {
+        let mut command_process = process::Command::new(&command.command);
+        command_process.args(&command.args);
+        if command.cur_dir.is_some() {
+            command_process.current_dir(command.cur_dir.clone().unwrap());
+        }
+        command_process.envs(command.env.clone());
+        command_process.stdout(process::Stdio::piped());
+        let command_name = command.name.clone();
+
+        let _ = send_chan.send(OutputMessage {
+            name: command_name.clone(),
+            message: OutputMessagePayload::Start,
+        });
+
+        let mut cmd_handle = command_process
+            .spawn()
+            .unwrap_or_else(|_| panic!("Unable to spawn process: {}", command.command.clone()));
+        let std_out = cmd_handle.stdout.take();
+        let std_err = cmd_handle.stderr.take();
+        let mut std_out_handle = None;
+        let mut std_err_handle = None;
+
+        let shared_handle = Arc::new(Mutex::new(cmd_handle));
+
+        let child_clone = shared_handle.clone();
+        let kill_trigger_clone = kill_trigger.clone();
+        thread::spawn(move || kill_thread(&kill_trigger_clone, child_clone));
+
+        if let Some(output) = std_out {
+            let mut buffered_stdout = BufReader::new(output);
+            let new_name = command_name.clone();
+            let new_chan = send_chan.clone();
+            std_out_handle = Some(thread::spawn(move || {
+                read_stream(&new_name, new_chan, &mut buffered_stdout, true);
+            }));
+        }
+
+        if let Some(output) = std_err {
+            let mut buffered_stdout = BufReader::new(output);
+            let new_name = command_name.clone();
+            let new_chan = send_chan.clone();
+            std_err_handle = Some(thread::spawn(move || {
+                read_stream(&new_name, new_chan, &mut buffered_stdout, false);
+            }));
+        }
+
+        if let Some(handle) = std_out_handle {
+            let _ = handle.join();
+        }
+
+        if let Some(handle) = std_err_handle {
+            let _ = handle.join();
+        }
+
+        let exit_status = shared_handle.lock().unwrap().wait();
+        match exit_status {
+            Ok(status) => {
+                let _ = send_chan.send(OutputMessage {
+                    name: command_name.clone(),
+                    message: OutputMessagePayload::Done(status.code()),
+                });
+
+                match options.restart {
+                    RestartOptions::Continue => {
+                        return (command_name, Some(status));
+                    }
+                    RestartOptions::Restart => {
+                        if status.success() {
+                            return (command_name, Some(status));
+                        }
+                    }
+                    RestartOptions::Kill => {
+                        if !status.success() {
+                            let _ = kill_trigger.initiate_kill();
+                        }
+                        return (command_name, Some(status));
+                    }
+                };
+            }
+            Err(e) => {
+                let _ = send_chan.send(OutputMessage {
+                    name: command_name.clone(),
+                    message: OutputMessagePayload::Error(e),
+                });
+                return (command_name, None);
+            }
+        }
+    })
+}
+
+fn kill_thread(kill_trigger: &kill_barrier::KillBarrier, child: Arc<Mutex<process::Child>>) {
+    let _ = kill_trigger.wait();
+
+    let lock_res = child.lock();
+    if let Ok(mut locked_child) = lock_res {
+        let _ = locked_child.kill();
+    }
+}
+
+fn read_stream<R>(
+    cmd_name: &str,
+    send_chan: mpsc::Sender<OutputMessage>,
+    reader: &mut R,
+    is_stdout: bool,
+) where
+    R: BufRead,
+{
+    loop {
+        let line = line_parse::get_line(reader);
+        match line {
+            Ok(Some(line_vec)) => {
+                let _ = send_chan.send(OutputMessage {
+                    name: cmd_name.to_string(),
+                    message: if is_stdout {
+                        OutputMessagePayload::Stdout(line_vec.0, line_vec.1)
+                    } else {
+                        OutputMessagePayload::Stderr(line_vec.0, line_vec.1)
+                    },
+                });
+            }
+            Ok(None) => {
+                return;
+            }
+            Err(e) => {
+                let _ = send_chan.send(OutputMessage {
+                    name: cmd_name.to_string(),
+                    message: OutputMessagePayload::Error(e),
+                });
+            }
+        }
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -57,10 +57,10 @@ fn run_command(
     options: Options,
     kill_trigger: kill_barrier::KillBarrier,
 ) -> thread::JoinHandle<ExitResult> {
-    thread::spawn(move || loop {
-        let mut command_process = command.to_stdlib_command();
-        let command_name = command.name.clone();
+    let command_name = command.name.clone();
+    let mut command_process: process::Command = command.into();
 
+    thread::spawn(move || loop {
         let _ = send_chan.send(OutputMessage {
             name: command_name.clone(),
             message: OutputMessagePayload::Start,

--- a/src/run.rs
+++ b/src/run.rs
@@ -58,13 +58,7 @@ fn run_command(
     kill_trigger: kill_barrier::KillBarrier,
 ) -> thread::JoinHandle<ExitResult> {
     thread::spawn(move || loop {
-        let mut command_process = process::Command::new(&command.command);
-        command_process.args(&command.args);
-        if command.cur_dir.is_some() {
-            command_process.current_dir(command.cur_dir.clone().unwrap());
-        }
-        command_process.envs(command.env.clone());
-        command_process.stdout(process::Stdio::piped());
+        let mut command_process = command.to_stdlib_command();
         let command_name = command.name.clone();
 
         let _ = send_chan.send(OutputMessage {


### PR DESCRIPTION
If a command isn't found, it returns a CommandNotFound error instead of panic'ing.

Addresses #20 