### PR TITLE
Move cur dir to command construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "currant"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "atty",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "currant"
 description = "A simple library to spawn concurrent shell processes in rust"
 documentation = "https://docs.rs/currant/latest/currant"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/examples/main_channel.rs
+++ b/examples/main_channel.rs
@@ -1,10 +1,17 @@
-use currant::{ChannelCommand, Command, OutputMessagePayload, Runner};
+use currant::{ChannelCommand, Command, OutputMessagePayload, Runner, CURRENT_WORKING_DIRECTORY};
 
 fn main() {
     let handle = Runner::new()
-        .command(ChannelCommand::from_string("test1", "ls -la .").unwrap())
-        .command(ChannelCommand::from_string("test2", "ls -la ..").unwrap())
-        .command(ChannelCommand::from_string("test3", "ls -la ../..").unwrap())
+        .command(
+            ChannelCommand::from_string("test1", "ls -la .", CURRENT_WORKING_DIRECTORY).unwrap(),
+        )
+        .command(
+            ChannelCommand::from_string("test2", "ls -la ..", CURRENT_WORKING_DIRECTORY).unwrap(),
+        )
+        .command(
+            ChannelCommand::from_string("test3", "ls -la ../..", CURRENT_WORKING_DIRECTORY)
+                .unwrap(),
+        )
         .execute();
 
     for msg in &handle {

--- a/examples/main_stdout.rs
+++ b/examples/main_stdout.rs
@@ -1,18 +1,18 @@
-use currant::{Color, Command, ConsoleCommand, Runner};
+use currant::{Color, Command, ConsoleCommand, Runner, CURRENT_WORKING_DIRECTORY};
 fn main() {
     let handle = Runner::new()
         .command(
-            ConsoleCommand::from_string("test1", "ls -la .")
+            ConsoleCommand::from_string("test1", "ls -la .", CURRENT_WORKING_DIRECTORY)
                 .unwrap()
                 .color(Color::BLUE),
         )
         .command(
-            ConsoleCommand::from_string("test2", "ls -la ..")
+            ConsoleCommand::from_string("test2", "ls -la ..", CURRENT_WORKING_DIRECTORY)
                 .unwrap()
                 .color(Color::RED),
         )
         .command(
-            ConsoleCommand::from_string("test3", "ls -la ../..")
+            ConsoleCommand::from_string("test3", "ls -la ../..", CURRENT_WORKING_DIRECTORY)
                 .unwrap()
                 .color(Color::GREEN),
         )

--- a/examples/main_writer.rs
+++ b/examples/main_writer.rs
@@ -1,4 +1,4 @@
-use currant::{Command, Runner, WriterCommand};
+use currant::{Command, Runner, WriterCommand, CURRENT_WORKING_DIRECTORY};
 use fs::File;
 use std::fs;
 
@@ -18,9 +18,15 @@ fn main() {
 
 fn run_cmds(file: File) {
     let handle = Runner::new()
-        .command(WriterCommand::from_string("test1", "ls -la .").unwrap())
-        .command(WriterCommand::from_string("test2", "ls -la ..").unwrap())
-        .command(WriterCommand::from_string("test3", "ls -la ../..").unwrap())
+        .command(
+            WriterCommand::from_string("test1", "ls -la .", CURRENT_WORKING_DIRECTORY).unwrap(),
+        )
+        .command(
+            WriterCommand::from_string("test2", "ls -la ..", CURRENT_WORKING_DIRECTORY).unwrap(),
+        )
+        .command(
+            WriterCommand::from_string("test3", "ls -la ../..", CURRENT_WORKING_DIRECTORY).unwrap(),
+        )
         .execute(file);
 
     handle.join().unwrap();

--- a/src/channel_api.rs
+++ b/src/channel_api.rs
@@ -6,12 +6,12 @@ use super::InnerCommand;
 /// This API provides the most flexibility at the cost of the most work to the user.
 /// ## Example:
 /// ```
-/// use currant::{ChannelCommand, Command, OutputMessagePayload, Runner};
+/// use currant::{ChannelCommand, Command, OutputMessagePayload, Runner, CURRENT_WORKING_DIRECTORY};
 ///
 /// let handle = Runner::new()
-///     .command(ChannelCommand::from_string("test1", "ls -la .").unwrap())
-///     .command(ChannelCommand::from_string("test2", "ls -la ..").unwrap())
-///     .command(ChannelCommand::from_string("test3", "ls -la ../..").unwrap())
+///     .command(ChannelCommand::from_string("test1", "ls -la .", CURRENT_WORKING_DIRECTORY).unwrap())
+///     .command(ChannelCommand::from_string("test2", "ls -la ..", CURRENT_WORKING_DIRECTORY).unwrap())
+///     .command(ChannelCommand::from_string("test3", "ls -la ../..", CURRENT_WORKING_DIRECTORY).unwrap())
 ///     .execute();
 ///
 /// for msg in &handle {

--- a/src/standard_out_api.rs
+++ b/src/standard_out_api.rs
@@ -19,21 +19,21 @@ use std::thread;
 /// In this case, currant will choose random but distinct colors so that all commands are as visually distant as possible.
 /// ## Example:
 /// ```
-/// use currant::{Color, Command, ConsoleCommand, Runner};
+/// use currant::{Color, Command, ConsoleCommand, Runner, CURRENT_WORKING_DIRECTORY};
 ///
 /// let handle = Runner::new()
 ///     .command(
-///         ConsoleCommand::from_string("test1", "ls -la .")
+///         ConsoleCommand::from_string("test1", "ls -la .", CURRENT_WORKING_DIRECTORY)
 ///             .unwrap()
 ///             .color(Color::BLUE),
 ///     )
 ///     .command(
-///         ConsoleCommand::from_string("test2", "ls -la ..")
+///         ConsoleCommand::from_string("test2", "ls -la ..", CURRENT_WORKING_DIRECTORY)
 ///             .unwrap()
 ///             .color(Color::RED),
 ///     )
 ///     .command(
-///         ConsoleCommand::from_string("test3", "ls -la ../..")
+///         ConsoleCommand::from_string("test3", "ls -la ../..", CURRENT_WORKING_DIRECTORY)
 ///             .unwrap()
 ///             .color(Color::GREEN),
 ///     )
@@ -234,17 +234,20 @@ mod tests {
     use crate::Command;
     use crate::RestartOptions;
     use crate::Runner;
+    use crate::CURRENT_WORKING_DIRECTORY;
 
     #[test]
     fn run_commands() {
         let handle = Runner::new()
-            .command(ConsoleCommand::from_string("test1", "ls -la .").unwrap())
-            .command(ConsoleCommand::from_string("test2", "ls -la ..").unwrap())
             .command(
-                ConsoleCommand::from_string("test3", "ls -la ../..")
-                    .unwrap()
-                    .cur_dir(".."),
+                ConsoleCommand::from_string("test1", "ls -la .", CURRENT_WORKING_DIRECTORY)
+                    .unwrap(),
             )
+            .command(
+                ConsoleCommand::from_string("test2", "ls -la ..", CURRENT_WORKING_DIRECTORY)
+                    .unwrap(),
+            )
+            .command(ConsoleCommand::from_string("test3", "ls -la ../..", Some("..")).unwrap())
             .restart(RestartOptions::Kill)
             .execute();
         let _ = handle.join();

--- a/src/which.rs
+++ b/src/which.rs
@@ -1,8 +1,15 @@
 use std::io::ErrorKind;
+use std::path::PathBuf;
 use std::process::Command;
 
-pub fn exec_exists(exec_name: &str) -> bool {
-    let child = Command::new(exec_name).spawn();
+pub fn exec_exists(exec_name: &str, dir: &Option<PathBuf>) -> bool {
+    let mut command = Command::new(exec_name);
+
+    if let Some(path) = dir {
+        command.current_dir(path);
+    }
+
+    let child = command.spawn();
 
     match child {
         Ok(mut c) => {

--- a/src/writer_api.rs
+++ b/src/writer_api.rs
@@ -17,6 +17,7 @@ use std::thread;
 /// use currant::Command;
 /// use currant::Runner;
 /// use currant::WriterCommand;
+/// use currant::CURRENT_WORKING_DIRECTORY;
 /// use fs::File;
 /// use std::fs;
 ///
@@ -37,9 +38,9 @@ use std::thread;
 /// fn run_cmds(file: File) {
 ///     // all commands output to the same writer
 ///     let handle = Runner::new()
-///         .command(WriterCommand::from_string("test1", "ls -la .").unwrap())
-///         .command(WriterCommand::from_string("test2", "ls -la ..").unwrap())
-///         .command(WriterCommand::from_string("test3", "ls -la ../..").unwrap())
+///         .command(WriterCommand::from_string("test1", "ls -la .", CURRENT_WORKING_DIRECTORY).unwrap())
+///         .command(WriterCommand::from_string("test2", "ls -la ..", CURRENT_WORKING_DIRECTORY).unwrap())
+///         .command(WriterCommand::from_string("test3", "ls -la ../..", CURRENT_WORKING_DIRECTORY).unwrap())
 ///         .execute(file);
 ///
 ///     handle.join().unwrap();


### PR DESCRIPTION
If the user has a custom `cur_dir` the command checks don't take that into account (since it `cur_dir` used to be set after command checks (non-existent exec, etc...)).
In order to solve this, I've moved `cur_dir` into the command constructor.